### PR TITLE
解决外部ScrollController无法监听滚动的问题

### DIFF
--- a/lib/src/refresher.dart
+++ b/lib/src/refresher.dart
@@ -1198,9 +1198,7 @@ class EasyRefreshState extends State<EasyRefresh>
                       semanticChildCount: widget.child is ScrollView
                           ? (widget.child as ScrollView).semanticChildCount
                           : 1,
-                      controller: widget.outerController == null
-                          ? _scrollController
-                          : null,
+                      controller: _scrollController,
                       physics: _scrollPhysics,
                       slivers: new List.from(slivers, growable: true),
                     ),


### PR DESCRIPTION
这里如果设置为空，则外部的ScrollController无法监听到滚动事件。https://github.com/xuelongqy/flutter_easyrefresh/issues/31