### PR TITLE
修复冲上云霄效果在下拉时，底部有边框线闪烁的问题（iPhone 6 P）

### DIFF
--- a/lib/taurus_header.dart
+++ b/lib/taurus_header.dart
@@ -12,7 +12,7 @@ class TaurusHeader extends Header {
   /// Key
   final Key key;
 
-/// 背景色
+  /// 背景色
   final Color backgroundColor;
 
   final LinkHeaderNotifier linkNotifier = LinkHeaderNotifier();
@@ -68,7 +68,7 @@ class TaurusHeader extends Header {
 
 /// 冲上云霄组件
 class TaurusHeaderWidget extends StatefulWidget {
-    /// 背景色
+  /// 背景色
   final Color backgroundColor;
 
   final LinkHeaderNotifier linkNotifier;

--- a/lib/taurus_header.dart
+++ b/lib/taurus_header.dart
@@ -212,7 +212,7 @@ class TaurusHeaderWidgetState extends State<TaurusHeaderWidget> {
     }
     return Stack(
       children: <Widget>[
-        // 蓝天
+        // 蓝天(背景)
         Container(
           width: double.infinity,
           color: widget.backgroundColor,

--- a/lib/taurus_header.dart
+++ b/lib/taurus_header.dart
@@ -12,10 +12,14 @@ class TaurusHeader extends Header {
   /// Key
   final Key key;
 
+/// 背景色
+  final Color backgroundColor;
+
   final LinkHeaderNotifier linkNotifier = LinkHeaderNotifier();
 
   TaurusHeader({
     this.key,
+    this.backgroundColor = Colors.blue,
     bool enableHapticFeedback = false,
   }) : super(
           extent: 90.0,
@@ -56,6 +60,7 @@ class TaurusHeader extends Header {
         noMore);
     return TaurusHeaderWidget(
       key: key,
+      backgroundColor: backgroundColor,
       linkNotifier: linkNotifier,
     );
   }
@@ -63,10 +68,14 @@ class TaurusHeader extends Header {
 
 /// 冲上云霄组件
 class TaurusHeaderWidget extends StatefulWidget {
+    /// 背景色
+  final Color backgroundColor;
+
   final LinkHeaderNotifier linkNotifier;
 
   const TaurusHeaderWidget({
     Key key,
+    this.backgroundColor = Colors.blue,
     this.linkNotifier,
   }) : super(key: key);
 
@@ -206,7 +215,7 @@ class TaurusHeaderWidgetState extends State<TaurusHeaderWidget> {
         // 蓝天
         Container(
           width: double.infinity,
-          color: Colors.blue,
+          color: widget.backgroundColor,
           transform: Matrix4.translationValues(
             0.0,
             -1.0,

--- a/lib/taurus_header.dart
+++ b/lib/taurus_header.dart
@@ -207,6 +207,11 @@ class TaurusHeaderWidgetState extends State<TaurusHeaderWidget> {
         Container(
           width: double.infinity,
           color: Colors.blue,
+          transform: Matrix4.translationValues(
+            0.0,
+            -1.0,
+            0.0,
+          ),
         ),
         // 左边云朵
         Positioned(
@@ -268,15 +273,17 @@ class TaurusHeaderWidgetState extends State<TaurusHeaderWidget> {
           bottom: -2.0,
           left: 0.0,
           right: 0.0,
-          child: Align(
-            alignment: Alignment.bottomCenter,
-            child: Container(
-              height: centerCloudHeight,
-              child: Image.memory(
-                _cloudsCenterBytes,
-                fit: BoxFit.fitHeight,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: <Widget>[
+              Container(
+                height: centerCloudHeight,
+                child: Image.memory(
+                  _cloudsCenterBytes,
+                  fit: BoxFit.fitHeight,
+                ),
               ),
-            ),
+            ],
           ),
         ),
       ],


### PR DESCRIPTION
在iPhone 6 Plus 上使用冲上云霄效果，下拉时在最底部会出现底部边框闪烁