### PR TITLE
fix: Avoid an endless loop caused by multiple ListViews nested.

### DIFF
--- a/lib/src/physics/scroll_physics.dart
+++ b/lib/src/physics/scroll_physics.dart
@@ -436,6 +436,9 @@ class _ERScrollPhysics extends BouncingScrollPhysics {
   @override
   Simulation? createBallisticSimulation(
       ScrollMetrics position, double velocity) {
+    // Avoid an endless loop caused by multiple ListViews nested.
+    if (position.maxScrollExtent == 0) return null;
+
     // User stopped scrolling.
     final oldUserOffset = userOffsetNotifier.value;
     userOffsetNotifier.value = false;


### PR DESCRIPTION
修复前的复现代码如下：

```dart
  Simulation? createBallisticSimulation(
      ScrollMetrics position, double velocity) {
    // 该方法在点击FloatingActionButton进行页面刷新后会不断地被调用
    print("position.maxScrollExtent -- ${position.maxScrollExtent}");
    ...
}
```

```dart
import 'package:easy_refresh/easy_refresh.dart';
import 'package:flutter/material.dart';

class Test1Page extends StatefulWidget {
  const Test1Page({super.key});

  @override
  State<Test1Page> createState() => _Test1PageState();
}

class _Test1PageState extends State<Test1Page> {
  List<int> sectionItemCountList = [3, 4, 3, 4];

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text('test'),
      ),
      body: _buildBody(),
      floatingActionButton: FloatingActionButton(
        child: Icon(Icons.refresh),
        onPressed: () {
          sectionItemCountList[2] = sectionItemCountList[2] + 1;
          setState(() {});
        },
      ),
    );
  }

  Widget _buildBody() {
    Widget resultWidget = CustomScrollView(slivers: [
      SliverList(
        delegate: SliverChildBuilderDelegate(
          (context, index) {
            return Column(
              children: [
                ListView.builder(
                  physics: NeverScrollableScrollPhysics(),
                  shrinkWrap: true,
                  itemBuilder: (context, index) {
                    return Container(
                      margin: EdgeInsets.all(8),
                      height: 80,
                      color: Colors.yellow,
                      child: Text("$index"),
                    );
                  },
                  itemCount: sectionItemCountList[index],
                ),
              ],
            );
          },
          childCount: sectionItemCountList.length,
        ),
      ),
    ]);

    resultWidget = EasyRefresh(
      onRefresh: () async {
        return Future.delayed(Duration(seconds: 1));
      },
      onLoad: () async {
        return Future.delayed(Duration(seconds: 1));
      },
      child: resultWidget,
    );
    return resultWidget;
  }
}
```

点击右下角的 `FloatingActionButton` 后，控制台会不停的输出：
```shell
...循环输出一样的内容
flutter: position.maxScrollExtent -- 0.0
flutter: position.maxScrollExtent -- 727.0
flutter: position.maxScrollExtent -- 0.0
flutter: position.maxScrollExtent -- 727.0
flutter: position.maxScrollExtent -- 0.0
flutter: position.maxScrollExtent -- 727.0
flutter: position.maxScrollExtent -- 0.0
flutter: position.maxScrollExtent -- 727.0
...循环输出一样的内容
```