### PR TITLE
fix: unexpected ScrollNotification

### DIFF
--- a/lib/src/physics/scroll_physics.dart
+++ b/lib/src/physics/scroll_physics.dart
@@ -453,7 +453,9 @@ class _ERScrollPhysics extends BouncingScrollPhysics {
             footerNotifier._mode == IndicatorMode.secondaryOpen);
     bool secondary = hSecondary || fSecondary;
     if (velocity.abs() >= tolerance.velocity ||
-        (oldMaxScrollExtent != position.maxScrollExtent &&
+        ((IndicatorMode.inactive != headerNotifier.mode ||
+                IndicatorMode.inactive != footerNotifier.mode) &&
+            oldMaxScrollExtent != position.maxScrollExtent &&
             position.maxScrollExtent != 0) ||
         (position.outOfRange || (secondary && oldUserOffset)) &&
             (oldUserOffset ||


### PR DESCRIPTION
如下视频所示，点击 `Grid`，往上滑动一段距离，再点击返回按钮，控制台会有 `NotificationListener` 的相应输出

https://github.com/user-attachments/assets/39ff4309-6750-49aa-9d34-27c5f1c7778e

经调试发现因 `(oldMaxScrollExtent != position.maxScrollExtent && position.maxScrollExtent != 0)` 成立，返回的 `simulation` 不为 `null` 而导致。

所以我将原来修复 https://github.com/xuelongqy/flutter_easy_refresh/issues/618 的代码进行了调整，仅在 `header` 或 `footer` 指示器的状态为非 `inactive` 时才做相关比较