### PR TITLE
fix: supplement the initialization of isNested

### DIFF
--- a/lib/src/easy_refresh.dart
+++ b/lib/src/easy_refresh.dart
@@ -406,6 +406,7 @@ class _EasyRefreshState extends State<EasyRefresh>
         vsync: this,
         onRefresh: _onRefresh,
         canProcessAfterNoMore: widget.canRefreshAfterNoMore,
+        isNested: widget.isNested,
         triggerAxis: widget.triggerAxis,
         waitRefreshResult: _waitRefreshResult,
         onCanRefresh: () {
@@ -422,6 +423,7 @@ class _EasyRefreshState extends State<EasyRefresh>
         vsync: this,
         onLoad: widget.onLoad,
         canProcessAfterNoMore: widget.canLoadAfterNoMore,
+        isNested: widget.isNested,
         triggerAxis: widget.triggerAxis,
         waitLoadResult: _waitLoadResult,
         onCanLoad: () {

--- a/lib/src/notifier/indicator_notifier.dart
+++ b/lib/src/notifier/indicator_notifier.dart
@@ -41,12 +41,14 @@ abstract class IndicatorNotifier extends ChangeNotifier {
     required this.userOffsetNotifier,
     required CanProcessCallBack onCanProcess,
     required bool canProcessAfterNoMore,
+    required bool isNested,
     Axis? triggerAxis,
     bool waitTaskResult = true,
     FutureOr Function()? task,
   })  : _indicator = indicator,
         _onCanProcess = onCanProcess,
         _canProcessAfterNoMore = canProcessAfterNoMore,
+        _isNested = isNested,
         _triggerAxis = triggerAxis,
         _waitTaskResult = waitTaskResult,
         _task = task {
@@ -148,7 +150,7 @@ abstract class IndicatorNotifier extends ChangeNotifier {
   ScrollMetrics get position => _position!;
 
   /// Handling NestedScrollView
-  bool _isNested = false;
+  bool _isNested;
 
   bool get isNested => _isNested;
 
@@ -955,6 +957,7 @@ class HeaderNotifier extends IndicatorNotifier {
     required super.vsync,
     required CanProcessCallBack onCanRefresh,
     super.canProcessAfterNoMore = false,
+    super.isNested = false,
     bool canProcessAfterFail = true,
     super.triggerAxis,
     FutureOr Function()? onRefresh,
@@ -1106,6 +1109,7 @@ class FooterNotifier extends IndicatorNotifier {
     required super.vsync,
     required CanProcessCallBack onCanLoad,
     super.canProcessAfterNoMore = false,
+    super.isNested = false,
     bool canProcessAfterFail = true,
     super.triggerAxis,
     FutureOr Function()? onLoad,


### PR DESCRIPTION
如下视频所示，当 `headerSliver` 所占用的高度足够多时，会出现拉不动的情况

https://github.com/user-attachments/assets/3262507c-c83a-4a73-ab74-94df64be8763

该 `PR` 的改动对新增的 `isNested` 的初始化做了补充，以解决该问题。