### PR TITLE
fix: Replace MediaQuery.of(context).padding with MediaQuery.paddingOf(context)

### DIFF
--- a/lib/src/easy_refresh.dart
+++ b/lib/src/easy_refresh.dart
@@ -538,7 +538,7 @@ class _EasyRefreshState extends State<EasyRefresh>
         final axis = _headerNotifier.axis!;
         final axisDirection = _headerNotifier.axisDirection!;
         // Set safe area offset.
-        final safePadding = MediaQuery.of(context).padding;
+        final safePadding = MediaQuery.paddingOf(context);
         _headerNotifier._safeOffset = axis == Axis.vertical
             ? axisDirection == AxisDirection.down
                 ? safePadding.top
@@ -589,7 +589,7 @@ class _EasyRefreshState extends State<EasyRefresh>
         final axis = _headerNotifier.axis!;
         final axisDirection = _headerNotifier.axisDirection!;
         // Set safe area offset.
-        final safePadding = MediaQuery.of(context).padding;
+        final safePadding = MediaQuery.paddingOf(context);
         _footerNotifier._safeOffset = axis == Axis.vertical
             ? axisDirection == AxisDirection.down
                 ? safePadding.bottom

--- a/lib/src/indicator/footer/footer_locator.dart
+++ b/lib/src/indicator/footer/footer_locator.dart
@@ -43,7 +43,7 @@ class FooterLocator extends StatelessWidget {
           final axis = footerNotifier.axis!;
           final axisDirection = footerNotifier.axisDirection!;
           // Set safe area offset.
-          final safePadding = MediaQuery.of(context).padding;
+          final safePadding = MediaQuery.paddingOf(context);
           footerNotifier._safeOffset = axis == Axis.vertical
               ? axisDirection == AxisDirection.down
                   ? safePadding.bottom

--- a/lib/src/indicator/header/header_locator.dart
+++ b/lib/src/indicator/header/header_locator.dart
@@ -43,7 +43,7 @@ class HeaderLocator extends StatelessWidget {
           final axis = headerNotifier.axis!;
           final axisDirection = headerNotifier.axisDirection!;
           // Set safe area offset.
-          final safePadding = MediaQuery.of(context).padding;
+          final safePadding = MediaQuery.paddingOf(context);
           headerNotifier._safeOffset = axis == Axis.vertical
               ? axisDirection == AxisDirection.down
                   ? safePadding.top


### PR DESCRIPTION
#855 MediaQuery.of(context).padding导致键盘区有变化时相关的组件都会rebuild。替换为新的api修复这个问题。